### PR TITLE
[ops] dotenv loader for the react client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ brew install yarn
 
 ```bash
 yarn
-yarn buildEnv
+yarn buildEnv {environment}
 yarn setup:rest-server
 yarn setup:socket-server
 yarn setup:client-server
 ```
+
 
 ### Start the Servers
 

--- a/bin/buildEnv.js
+++ b/bin/buildEnv.js
@@ -1,11 +1,19 @@
 const fs = require("fs");
 const path = require("path");
-const envBuild = require("../config/.env.js");
+const config = require("../config/.env.js");
+const environment = process.argv[2];
+
+if (!config[environment]) {
+  console.warn('Could not find a configuration for the environment provided');
+  process.exit(1);
+} else {
+  console.log(`ENV:  Building environment for ${environment}`)
+}
 
 const buildEnv = () => {
-  for (let pathname in envBuild) {
+  for (let pathname in config[environment]) {
     fs.writeFileSync(__dirname + `/../${pathname}/.env`, "");
-    envBuild[pathname].forEach(variable =>
+    config[environment][pathname].forEach(variable =>
       fs.appendFileSync(__dirname + `/../${pathname}/.env`, variable + "\n")
     );
   }

--- a/client/src/components/GameBoard/PlayerPanel.jsx
+++ b/client/src/components/GameBoard/PlayerPanel.jsx
@@ -4,7 +4,7 @@ import './PlayerPanel.css';
 
 const PlayerPanel = ({ player }) => {
   let avatarStyles = {
-    backgroundImage: `url(${player.user.avatar})`,
+    backgroundImage: `url(${process.env.REACT_APP_AVATAR_URL}/${player.user.avatar})`,
   }
   return (
     <div className={`player__profile-${player.facing}`}>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,4 +1,14 @@
-// require('dotenv').config();
+const path = require('path');
+const dotenv = require('dotenv').config({ path: path.resolve(__dirname, './.env') });
+
+const envPrefix = dotenv.parsed.ENVPREFIX || '';
+let envVars = Object.entries(dotenv.parsed).reduce((obj, [key, value]) => {
+  let match = new RegExp('^' + envPrefix, 'i');
+  if (match.test(key)) {
+    obj[key] = JSON.stringify(value);
+  }
+  return obj;
+}, {})
 
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
@@ -63,7 +73,12 @@ module.exports = {
         ]
       }
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': envVars,
+    })
+  ]
   // plugins: [
   //   new ExtractTextPlugin('./client/styles/main.css', {
   //     allChunks: true

--- a/config/.env.sample.js
+++ b/config/.env.sample.js
@@ -1,47 +1,96 @@
 const envBuild = {
-  "rest-server": [
-    "DEBUG=TRUE",
-    "NODE_ENV=test",
-    "PORT=3396",
-    "LOCAL_USER=root",
-    "LOCAL_HOST=localhost",
-    "LOCAL_DATABASE=grandmaster",
-    "LOCAL_PASSWORD=",
-    "LOCAL_PORT=5432",
-    "AWS_USER=",
-    "AWS_HOST=",
-    "AWS_DATABASE=",
-    "AWS_PASSWORD=",
-    "AWS_PORT=",
-    "SALT_ROUNDS=10",
-    "TOKEN_SECRET=grandmasterapi"
-  ],
-  "socket-server": [
-    "NODE_ENV=DEVELOPMENT",
-    "DEBUG=TRUE",
-    "HOST=http://localhost",
-    "PORT=4155",
-    "REST_SERVER_URL=http://localhost:4990",
-    "TOKEN_SECRET=grandmaster"
-  ],
-  "client/server": ["PORT=1337"],
-  "client": [
-    "NODE_ENV=DEVELOPMENT",
-    "DEBUG=TRUE",
-    "ENVPREFIX=REACT_APP_",
-    "REST_SERVER_URL=http://localhost:4990",
-    "SOCKET_SERVER_URL=http://localhost:4155",
-    "REACT_APP_SOCKET_SERVER_URL=http://localhost:4155",
-    "REACT_APP_REST_SERVER_URL=http://localhost:4990"
-  ],
-  "services/boardsolver": [
-    "NODE_ENV=DEVELOPMENT",
-    "DEBUG=TRUE",
-    "HOST=http://localhost",
-    "PORT=4000",
-    "REST_SERVER_URL=http://localhost:3396",
-    "SOCKET_SERVER_URL=http://localhost:4155"
-  ],
+  production: {
+    "rest-server": [
+      "DEBUG=FALSE",
+      "NODE_ENV=production",
+      "PORT=3396",
+      "LOCAL_USER=root",
+      "LOCAL_HOST=localhost",
+      "LOCAL_DATABASE=grandmaster",
+      "LOCAL_PASSWORD=",
+      "LOCAL_PORT=5432",
+      "AWS_USER=",
+      "AWS_HOST=",
+      "AWS_DATABASE=",
+      "AWS_PASSWORD=",
+      "AWS_PORT=",
+      "SALT_ROUNDS=10",
+      "TOKEN_SECRET=grandmasterapi"
+    ],
+    "socket-server": [
+      "NODE_ENV=PRODUCTION",
+      "DEBUG=FALSE",
+      "HOST=http://localhost",
+      "PORT=4155",
+      "REST_SERVER_URL=http://localhost:4990",
+      "TOKEN_SECRET=grandmaster"
+    ],
+    "client/server": ["PORT=1337"],
+    "client": [
+      "NODE_ENV=PRODUCTION",
+      "DEBUG=FALSE",
+      "ENVPREFIX=REACT_APP_",
+      "REST_SERVER_URL=http://localhost:4990",
+      "SOCKET_SERVER_URL=http://localhost:4155",
+      "REACT_APP_SOCKET_SERVER_URL=http://localhost:4155",
+      "REACT_APP_REST_SERVER_URL=http://localhost:4990",
+      "REACT_APP_AVATAR_URL=https://res.cloudinary.com/shogigrandmasters/image/upload/"
+    ],
+    "services/boardsolver": [
+      "NODE_ENV=PRODUCTION",
+      "DEBUG=FALSE",
+      "HOST=http://localhost",
+      "PORT=4000",
+      "REST_SERVER_URL=http://localhost:3396",
+      "SOCKET_SERVER_URL=http://localhost:4155"
+    ],
+  },
+  development: {
+    "rest-server": [
+      "DEBUG=TRUE",
+      "NODE_ENV=test",
+      "PORT=3396",
+      "LOCAL_USER=root",
+      "LOCAL_HOST=localhost",
+      "LOCAL_DATABASE=grandmaster",
+      "LOCAL_PASSWORD=",
+      "LOCAL_PORT=5432",
+      "AWS_USER=",
+      "AWS_HOST=",
+      "AWS_DATABASE=",
+      "AWS_PASSWORD=",
+      "AWS_PORT=",
+      "SALT_ROUNDS=10",
+      "TOKEN_SECRET=grandmasterapi"
+    ],
+    "socket-server": [
+      "NODE_ENV=DEVELOPMENT",
+      "DEBUG=TRUE",
+      "HOST=http://localhost",
+      "PORT=4155",
+      "REST_SERVER_URL=http://localhost:4990",
+      "TOKEN_SECRET=grandmaster"
+    ],
+    "client/server": ["PORT=1337"],
+    "client": [
+      "NODE_ENV=DEVELOPMENT",
+      "DEBUG=TRUE",
+      "ENVPREFIX=REACT_APP_",
+      "REST_SERVER_URL=http://localhost:4990",
+      "SOCKET_SERVER_URL=http://localhost:4155",
+      "REACT_APP_SOCKET_SERVER_URL=http://localhost:4155",
+      "REACT_APP_REST_SERVER_URL=http://localhost:4990",
+      "REACT_APP_AVATAR_URL=https://res.cloudinary.com/shogigrandmasters/image/upload/"
+    ],
+    "services/boardsolver": [
+      "NODE_ENV=DEVELOPMENT",
+      "DEBUG=TRUE",
+      "HOST=http://localhost",
+      "PORT=4000",
+      "REST_SERVER_URL=http://localhost:3396",
+      "SOCKET_SERVER_URL=http://localhost:4155"
+    ],
+  }
 };
 
 module.exports = envBuild;


### PR DESCRIPTION
- "yarn buildEnv" now requires a third argument that points to an environment name in env.js
- ex: yarn buildEnv production
- variables with the prefix defined in env.js (currently 'REACT_APP_') are loaded to process.env for client use